### PR TITLE
Return raw slices in Getter impls

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -152,7 +152,7 @@ func (f *StringSlice) Value() []string {
 
 // Get returns the slice of strings set by this flag
 func (f *StringSlice) Get() interface{} {
-	return *f
+	return []string(*f)
 }
 
 // Apply populates the flag given the flag set and environment
@@ -215,7 +215,7 @@ func (f *IntSlice) Value() []int {
 
 // Get returns the slice of ints set by this flag
 func (f *IntSlice) Get() interface{} {
-	return *f
+	return []int(*f)
 }
 
 // Apply populates the flag given the flag set and environment
@@ -278,7 +278,7 @@ func (f *Int64Slice) Value() []int64 {
 
 // Get returns the slice of ints set by this flag
 func (f *Int64Slice) Get() interface{} {
-	return *f
+	return []int64(*f)
 }
 
 // Apply populates the flag given the flag set and environment


### PR DESCRIPTION
The Getter interface should return the value, not the wrapped value, i.e. `[]string`, not `StringSlice`.